### PR TITLE
Fix URL of did.json

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -134,7 +134,7 @@ For the domain name `w3c-ccg.github.io`, the `did.json` will be available under
 the following URL:
 
 ```
-did:web:w3c-ccg.github.io/.well-known/did.json
+https://w3c-ccg.github.io/.well-known/did.json
 ```
 
 ### Read (Resolve)


### PR DESCRIPTION
If I understand correctly, here you want to state the HTTPS URL of the did.json file, not a DID URL, or? Sorry if I misunderstood.