### PR TITLE
Update to reflect DID Core changes (publicKey, context).

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,18 +109,17 @@ Add non-ethereum example keys (ed25519, RSA, etc)
 
         <pre class="example" title="Example did:web DID document">
 {
-  "@context": "https://w3id.org/did/v1",
+  "@context": "https://www.w3.org/ns/did/v1",
   "id": "did:web:example.com",
-  "publicKey": [{
-       "id": "did:web:example.com#owner",
-       "type": "Secp256k1VerificationKey2018",
-       "owner": "did:web:example.com",
-       "ethereumAddress": "0xb9c5714089478a327f09197987f16f9e5d936e8a"
+  "verificationMethod": [{
+     "id": "did:web:example.com#owner",
+     "type": "Secp256k1VerificationKey2018",
+     "owner": "did:web:example.com",
+     "ethereumAddress": "0xb9c5714089478a327f09197987f16f9e5d936e8a"
   }],
-  "authentication": [{
-       "type": "Secp256k1SignatureAuthentication2018",
-       "publicKey": "did:web:example.com#owner"
-  }]
+  "authentication": [
+     "did:web:example.com#owner"
+  ]
 }
         </pre>
       </section>
@@ -352,7 +351,7 @@ DNS Considerations
           </h3>
           <h4>
 DNS Security Considerations
-          </h4>          
+          </h4>
             <p>
 DNS presents many of the attack vectors that enable active security and privacy
 attacks on the did:web method and it's important that implementors address these
@@ -367,8 +366,8 @@ Additionally, implementors should be aware of issues presented by a Spoofed DNS
 records where the record returned by a malicious DNS Server is inauthentic and
 allows the record to be pointed at a malicious server which contains a different
 DID Document. To prevent this type of issue, usage of DNSSEC which is defined in
-<a href="https://tools.ietf.org/html/rfc4033">RFC4033</a>, 
-<a href="https://tools.ietf.org/html/rfc4034">RFC4034</a>, and 
+<a href="https://tools.ietf.org/html/rfc4033">RFC4033</a>,
+<a href="https://tools.ietf.org/html/rfc4034">RFC4034</a>, and
 <a href="https://tools.ietf.org/html/rfc4035">RFC4035</a>.
             </p>
 


### PR DESCRIPTION
Addresses issue #27.

Updates example DID Document to match pre-CR changes to the DID Core spec.

* Change DID core context to `https://www.w3.org/ns/did/v1`
* Rename `publicKey` to `verificationMethod` (per did core spec).