### PR TITLE
Remove the spec Editors from Digital Bazaar.

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,21 +12,10 @@
         wgURI: "https://www.w3.org/community/credentials/",
         wgPublicList: "public-credentials",
         editors: [{
-          name: "Dmitri Zagidulin",
-          email: "dzagidulin@gmail.com"
-        },
-        {
           name: "Oliver Terbu",
           email: "oliver.terbu@consensys.net",
           company: "Consensys",
           companyURL: "https://consensys.net"
-        },
-        {
-          name: "Amy Guy",
-          url: "https://rhiaro.co.uk",
-          company: "Digital Bazaar",
-          companyURL: "https://digitalbazaar.com",
-          email: "amy@rhiaro.co.uk"
         }],
         authors: [
         {


### PR DESCRIPTION
This PR removes the spec Editors from Digital Bazaar as other Editors would like to step forward to move the specification forward at a faster rate than it's been progressing.