### PR TITLE
Transmute wants to be an editor of this work item

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,12 @@
           email: "oliver.terbu@consensys.net",
           company: "Consensys",
           companyURL: "https://consensys.net"
+        },{
+          name: "Orie Steele",
+          url: "https://www.linkedin.com/in/or13b/",
+          company: "Transmute",
+          companyURL: "https://www.transmute.industries/",
+          w3cid: 109171
         }],
         authors: [
         {


### PR DESCRIPTION
In order to conform with W3C CCG guidelines a work item must be supported by 2 independent companies,  this PR adds myself and Transmute as an editor for the work item, and indicates our intention to be responsible for implementing work item consensus as determined by meetings / issues.