### PR TITLE
Verify document.id after resolution

### DIFF
--- a/index.html
+++ b/index.html
@@ -417,7 +417,7 @@ did:web:example.com%3A3000:user:alice
               href="#security-and-privacy-considerations"></a>.
           </li>
           <li>
-            Verify the ID of resolved DID document equals the Web DID being resolved.
+            Verify that the ID of the resolved DID document matches the Web DID being resolved.
           </li>
           <li>
             When performing the DNS resolution during the HTTP <code>GET</code>

--- a/index.html
+++ b/index.html
@@ -417,6 +417,9 @@ did:web:example.com%3A3000:user:alice
               href="#security-and-privacy-considerations"></a>.
           </li>
           <li>
+            Verify the ID of resolved DID document equals the Web DID being resolved.
+          </li>
+          <li>
             When performing the DNS resolution during the HTTP <code>GET</code>
             request, the client SHOULD utilize [[RFC8484]] in order to prevent
             tracking of the identity being resolved.


### PR DESCRIPTION
To mitigate (accidentally) misconfigured HTTP servers.

(as implemented by https://github.com/decentralized-identity/web-did-resolver/blob/master/src/resolver.ts#L40)

Fixes https://github.com/w3c-ccg/did-method-web/issues/79